### PR TITLE
[2975][2979][FIX] auction_seller_invoice: Hide some report/action and add rules

### DIFF
--- a/auction_seller_invoice/README.rst
+++ b/auction_seller_invoice/README.rst
@@ -22,6 +22,8 @@ Auction Seller Invoice
 This module does the following:
 
 - Adds vendor bill views to show the relevant records to sellers, and a kanban tile to the seller dashboard to open the views.
+- Hides actions and reports that portal users do not need to use.
+- Prevents portal users to see other users' settlement records.
 
 **Table of contents**
 

--- a/auction_seller_invoice/__manifest__.py
+++ b/auction_seller_invoice/__manifest__.py
@@ -16,6 +16,8 @@
         "security/ir.model.access.csv",
         "security/auction_security.xml",
         "data/seller_board_data.xml",
+        "data/ir_actions_server_data.xml",
+        "data/ir_actions_report_data.xml",
         "views/auction_item_invoice_views.xml",
         "views/seller_board_views.xml",
     ],

--- a/auction_seller_invoice/data/ir_actions_report_data.xml
+++ b/auction_seller_invoice/data/ir_actions_report_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account.action_account_original_vendor_bill" model="ir.actions.report">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
+    </record>
+    <record id="account.account_invoices_without_payment" model="ir.actions.report">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
+    </record>
+    <record id="commission.action_report_settlement" model="ir.actions.report">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
+    </record>
+</odoo>

--- a/auction_seller_invoice/data/ir_actions_server_data.xml
+++ b/auction_seller_invoice/data/ir_actions_server_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account.invoice_send" model="ir.actions.server">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
+    </record>
+</odoo>

--- a/auction_seller_invoice/data/ir_actions_server_data.xml
+++ b/auction_seller_invoice/data/ir_actions_server_data.xml
@@ -3,4 +3,26 @@
     <record id="account.invoice_send" model="ir.actions.server">
         <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
     </record>
+
+    <function name="write" model="ir.model.data">
+        <function name="search" model="ir.model.data">
+            <value
+                eval="[('name', '=', 'model_account_move_action_share'), ('module', '=', 'account')]"
+            />
+        </function>
+        <value eval="{'noupdate': False}" />
+    </function>
+
+    <record id="account.model_account_move_action_share" model="ir.actions.server">
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
+    <function name="write" model="ir.model.data">
+        <function name="search" model="ir.model.data">
+            <value
+                eval="[('name', '=', 'model_account_move_action_share'), ('module', '=', 'account')]"
+            />
+        </function>
+        <value eval="{'noupdate': True}" />
+    </function>
 </odoo>

--- a/auction_seller_invoice/readme/DESCRIPTION.rst
+++ b/auction_seller_invoice/readme/DESCRIPTION.rst
@@ -1,3 +1,5 @@
 This module does the following:
 
 - Adds vendor bill views to show the relevant records to sellers, and a kanban tile to the seller dashboard to open the views.
+- Hides actions and reports that portal users do not need to use.
+- Prevents portal users to see other users' settlement records.

--- a/auction_seller_invoice/security/auction_security.xml
+++ b/auction_seller_invoice/security/auction_security.xml
@@ -20,4 +20,15 @@
             eval="[Command.link(ref('account.group_account_invoice'))]"
         />
     </record>
+    <record id="auction_seller_settlement_rule" model="ir.rule">
+        <field name="name">commission.settlemnent Auction Seller Invoice</field>
+        <field name="model_id" ref="commission.model_commission_settlement" />
+        <field
+            name="domain_force"
+        >[('agent_id.commercial_partner_id','=',user.commercial_partner_id.id)]</field>
+        <field
+            name="groups"
+            eval="[Command.link(ref('auction_seller.group_auction_seller'))]"
+        />
+    </record>
 </odoo>

--- a/auction_seller_invoice/static/description/index.html
+++ b/auction_seller_invoice/static/description/index.html
@@ -371,6 +371,8 @@ ul.auto-toc {
 <p>This module does the following:</p>
 <ul class="simple">
 <li>Adds vendor bill views to show the relevant records to sellers, and a kanban tile to the seller dashboard to open the views.</li>
+<li>Hides actions and reports that portal users do not need to use.</li>
+<li>Prevents portal users to see other users’ settlement records.</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">


### PR DESCRIPTION
[2975](https://www.quartile.co/web?#id=2975&action=771&model=project.task&view_type=form&menu_id=505)
[2979](https://www.quartile.co/web?#id=2979&action=771&model=project.task&view_type=form&menu_id=505)

I have made some changes for Portal users.
- Hide actions and reports that portal users do not need to use.
- Prevents portal users to see other users' settlement records.