### PR TITLE
[FIX] account_commission_listing_fee: Fix translation

### DIFF
--- a/account_commission_listing_fee/i18n/ja.po
+++ b/account_commission_listing_fee/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-05 05:29+0000\n"
-"PO-Revision-Date: 2023-01-05 05:29+0000\n"
+"POT-Creation-Date: 2023-03-06 05:48+0000\n"
+"PO-Revision-Date: 2023-03-06 05:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +19,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_commission_listing_fee.field_commission__calculate_listing_fee
 msgid "Calculate Listing Fee"
 msgstr "出品料を計算"
+
+#. module: account_commission_listing_fee
+#: model:ir.model.fields,field_description:account_commission_listing_fee.field_commission_settlement_line__case_number
+msgid "Case Number"
+msgstr "箱番号"
 
 #. module: account_commission_listing_fee
 #: model:ir.model,name:account_commission_listing_fee.model_commission
@@ -38,7 +43,7 @@ msgstr "イベント"
 #. module: account_commission_listing_fee
 #: model:ir.model,name:account_commission_listing_fee.model_commission_settlement_line
 msgid "Line of a commission settlement"
-msgstr ""
+msgstr "コミッション精算明細"
 
 #. module: account_commission_listing_fee
 #: model:ir.model.fields,field_description:account_commission_listing_fee.field_res_partner__listing_fee_product_id
@@ -56,12 +61,6 @@ msgstr "アイテム数"
 #: model:ir.model.fields,field_description:account_commission_listing_fee.field_commission_settlement_line__product_id
 msgid "Product"
 msgstr "プロダクト"
-
-#. module: account_commission_listing_fee
-#: model:ir.model,name:account_commission_listing_fee.model_product_product
-#: model:ir.model.fields,field_description:account_commission_listing_fee.field_commission_settlement_line__case_number
-msgid "Case Number"
-msgstr "箱番号"
 
 #. module: account_commission_listing_fee
 #: model:ir.model,name:account_commission_listing_fee.model_commission_settlement


### PR DESCRIPTION
I got `psycopg2.errors.CardinalityViolation: ON CONFLICT DO UPDATE command cannot affect row a second time
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.` error when I tried to update Japanese Translation. (I pressed Settings>Translation>Languages>Japanese>Update button to update existing translations)

I checked the logs with the error, and it seemed that the error was happend by the translation of the account_commission_listing_fee module. So I have updated the account_commission_listing_fee translation file.
And I was able to fix the error.

![2023-03-06_14h58_52](https://user-images.githubusercontent.com/101688144/223030555-6f9b683b-1ff8-4219-ba8a-fdf32e88c460.png)
