### PR TITLE
[3859][15.0][IMP] partner_secondhand_dealer: add new fields

### DIFF
--- a/partner_secondhand_dealer/models/res_partner.py
+++ b/partner_secondhand_dealer/models/res_partner.py
@@ -12,5 +12,7 @@ class ResPartner(models.Model):
         string="Identification Type",
     )
     identification_number = fields.Char()
+    fax = fields.Char()
+    gender = fields.Selection([("male", "Male"), ("female", "Female")])
     occupation_id = fields.Many2one("res.occupation", "Occupation")
     date_birth = fields.Date("Date of Birth")

--- a/partner_secondhand_dealer/views/res_partner_views.xml
+++ b/partner_secondhand_dealer/views/res_partner_views.xml
@@ -6,6 +6,12 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='function']" position="after">
+                <field name="gender" widget="radio" />
+            </xpath>
+            <xpath expr="//field[@name='user_ids']" position="after">
+                <field name="fax" />
+            </xpath>
             <xpath expr="//notebook/page[@name='internal_notes']" position="after">
                 <page string="Secondhand Attributes" name="secondhand_attributes">
                     <group>
@@ -24,6 +30,19 @@
                 <field name="occupation_id" />
                 <field name="identification_type_id" />
                 <field name="identification_number" />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_res_partner_filter" model="ir.ui.view">
+        <field name="name">res.partner.select</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="before">
+                <field
+                    name="phone"
+                    filter_domain="['|', ('phone', 'ilike', self), ('mobile', 'ilike', self)]"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[3859](https://www.quartile.co/web#id=3859&cids=3&model=project.task&view_type=form)

Identification type is not the same model with partner_attribute_sst. May be we can use name as indentifier for mapping.