### PR TITLE
[15.0][FIX] base_auction: remove is_auction_user from mixin model

### DIFF
--- a/base_auction/models/mail_activity_mixin.py
+++ b/base_auction/models/mail_activity_mixin.py
@@ -7,9 +7,6 @@ from odoo import fields, models
 class MailActivityMixin(models.AbstractModel):
     _inherit = "mail.activity.mixin"
 
-    is_auction_user = fields.Boolean(
-        compute="_compute_is_auction_user", inverse="_inverse_is_auction_user"
-    )
     # Ading base_auction.group_auction_user to prevent access errors.
     # TODO: Check if this change is really valid.
     activity_ids = fields.One2many(


### PR DESCRIPTION
This PR removes the `is_auction_user` field from `mail.activity.mixin `. This field is compute field and I have no idea the background of why the compute function is not implemented within this model.
This will cause issue when we try to create some record of model that inherits this mixin model(eg.sale.order).
I checked where this field is used and I found this field is only used in `res.users` model and there is field definition and compute function definition. So, this PR is created to remove this field from mixin model.