### PR TITLE
[4563][FIX] product_carousel_image_attachment

### DIFF
--- a/product_carousel_image_attachment/models/ir_attachment.py
+++ b/product_carousel_image_attachment/models/ir_attachment.py
@@ -13,10 +13,15 @@ class IrAttachment(models.Model):
     def create(self, vals_list):
         attachments = super(IrAttachment, self).create(vals_list)
         for attachment in attachments:
-            if attachment.mimetype in IMAGE_TYPES and attachment.res_model in [
-                "product.template",
-                "product.product",
-            ]:
+            if (
+                attachment.mimetype in IMAGE_TYPES
+                and attachment.res_model
+                in [
+                    "product.template",
+                    "product.product",
+                ]
+                and not attachment.res_field
+            ):
                 vals = {}
                 # assignment for pt and p
                 if attachment.res_model == "product.template":


### PR DESCRIPTION
This PR is to fix the expected behavior that is adding as carousel image when we add new images in product that is not from chatter.

[4563](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=4563)