### PR TITLE
[5044][IMP] account_commission_sales_fee: Include zero-price items in commission calculation

### DIFF
--- a/account_commission_sales_fee/models/commission_settlement.py
+++ b/account_commission_sales_fee/models/commission_settlement.py
@@ -13,7 +13,7 @@ class CommissionSettlement(models.Model):
             "quantity": len(
                 self.line_ids.filtered(
                     lambda line: line.commission_id == commission
-                    and line.settled_amount > 0.0
+                    and line.settled_amount >= 0.0
                 )
             ),
             "price_unit": commission.sales_fee_product_id.list_price * -1,


### PR DESCRIPTION
[5044](https://www.quartile.co/web?db=qrtl&token=z9OpY14OSBGGYn2qv0Ha#id=5044&cids=3&menu_id=505&action=1457&model=project.task&view_type=form)
- Adjusted the logic to count records with `line.settled_amount >= 0.0` for commissionable items.